### PR TITLE
fixed error with setting lat long

### DIFF
--- a/js/welcome.js
+++ b/js/welcome.js
@@ -138,7 +138,7 @@ function displayCityList(selectedProvince) {
   });
 }
 
-function convertCityToLatLong(cityName) {
+function setLatLongFromCity(cityName) {
   const geocoder = new google.maps.Geocoder();
 
   geocoder.geocode({ address: cityName }, function (results, status) {
@@ -146,7 +146,8 @@ function convertCityToLatLong(cityName) {
       const lat = results[0].geometry.location.lat();
       const lng = results[0].geometry.location.lng();
 
-      return { lat, lng };
+      localStorage.setItem(LOCAL_STORAGE_KEYS.lat, lat);
+      localStorage.setItem(LOCAL_STORAGE_KEYS.long, lng);
     } else {
       alert("Geocode was not successful for the following reason: " + status);
     }
@@ -161,12 +162,7 @@ function submitCity() {
     provinceSelect.options[provinceSelect.selectedIndex].value;
   const selectedCity = citySelect.options[citySelect.selectedIndex].value;
 
-  const { lat, lng } = convertCityToLatLong(
-    `${selectedCity}, ${selectedProvince}, Canada`
-  );
-
-  localStorage.setItem(LOCAL_STORAGE_KEYS.lat, lat);
-  localStorage.setItem(LOCAL_STORAGE_KEYS.long, lng);
+  setLatLongFromCity(`${selectedCity}, ${selectedProvince}, Canada`);
   //TODO: タイムゾーンを取得してLocalStorageに保存する
 }
 


### PR DESCRIPTION
https://github.com/makoto0825/WeatherApp/pull/32/commits/6f5ff7de36f8d98c4d41c6cceb6dcd214a537d8c
上記で行った修正で発生したバグの対応
awaitしていないためsetLocalStorageがタイミング的にうまくいっていなかった。
google map apiのgeocoderはpromiseを返さないため、awaitを使えないので、コールバックでlocalStorageにセットすることにした